### PR TITLE
Convert words.txt to UTF-8

### DIFF
--- a/words.txt
+++ b/words.txt
@@ -1,19 +1,19 @@
-авангард :: vanguard ::
+Р°РІР°РЅРіР°СЂРґ :: vanguard ::
 
-запасник :: storeroom ::
+Р·Р°РїР°СЃРЅРёРє :: storeroom ::
 
-предел :: limit ::
+РїСЂРµРґРµР» :: limit ::
 
-семь :: seven ::
+СЃРµРјСЊ :: seven ::
 
-талон :: card ::
+С‚Р°Р»РѕРЅ :: card ::
 
-управляющий :: superintendant ::
+СѓРїСЂР°РІР»СЏСЋС‰РёР№ :: superintendant ::
 
-упражнение :: exercise ::
+СѓРїСЂР°Р¶РЅРµРЅРёРµ :: exercise ::
 
-этап :: stage ::
+СЌС‚Р°Рї :: stage ::
 
-этаж :: floor ::
+СЌС‚Р°Р¶ :: floor ::
 
-засада :: snare ::
+Р·Р°СЃР°РґР° :: snare ::


### PR DESCRIPTION
The words.txt file was windows-1251 encoded, not in UTF-8, despite the processing is. It results in error:

```
eng.rb:36:in `split': invalid byte sequence in UTF-8 (ArgumentError)
	from eng.rb:36:in `block in <main>'
	from eng.rb:35:in `foreach'
	from eng.rb:35:in `<main>'
```

Appears on OS X 10.11.6 and ruby-2.3.1.

This PR fixes the error by converting the words file to UTF-8.